### PR TITLE
Stripping out the which command

### DIFF
--- a/lib/youtube-dl/runner.rb
+++ b/lib/youtube-dl/runner.rb
@@ -75,7 +75,7 @@ module YoutubeDL
     def usable_executable_path
       system_path = `which youtube-dl`
       if $?.exitstatus == 0
-        system_path
+        system_path.strip
       else
         vendor_path = File.absolute_path("#{__FILE__}/../../../vendor/bin/youtube-dl")
         File.chmod(775, vendor_path) unless File.executable?(vendor_path) # Make sure vendor binary is executable

--- a/test/youtube-dl/runner_test.rb
+++ b/test/youtube-dl/runner_test.rb
@@ -21,6 +21,14 @@ describe YoutubeDL::Runner do
     assert_match 'youtube-dl', @runner.executable_path
   end
 
+  it 'should not have a newline char in the executable_path' do
+    assert_match /youtube-dl\z/, @runner.executable_path
+  end
+
+  it 'should not have newline char in to_command' do
+    assert_match /youtube-dl\s/, @runner.to_command
+  end
+
   it 'should parse key-values from options' do
     @runner.options.some_key = "a value"
 


### PR DESCRIPTION
Fixing issue where `which youtube-dl` was getting returned with a newline at the end.