### PR TITLE
Unquoted url

### DIFF
--- a/lib/youtube-dl/runner.rb
+++ b/lib/youtube-dl/runner.rb
@@ -57,8 +57,12 @@ module YoutubeDL
           commands.push "--#{paramized_key} :#{key}"
         end
       end
-      commands.push url
+      commands.push quoted(url)
       commands.join(' ')
+    end
+
+    def quoted(url)
+      "\"#{url}\""
     end
 
     # Helper for doing lines of cocaine (initializing, auto executable stuff, etc)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,7 +17,7 @@ require 'fileutils'
 
 require 'youtube-dl'
 
-TEST_URL = "https://www.youtube.com/watch?v=gvdf5n-zI14"
+TEST_URL = "https://www.youtube.com/watch?feature=endscreen&v=gvdf5n-zI14"
 TEST_URL2 = "https://www.youtube.com/watch?v=Mt0PUjh-nDM"
 TEST_FILENAME = "nope.avi.mp4"
 TEST_FORMAT = "5"


### PR DESCRIPTION
Currently some urls cannot be handled by youtube-dl.rb since the url as command line parameter is not wrapped in quotes.

One real world example would be:
https://www.youtube.com/watch?NR=1&feature=endscreen&v=lhFSc0dWsto

I adapted one test url for this case and fixed the implementation.