### PR TITLE
Refactor a lot of how options are handled within Video class

### DIFF
--- a/lib/youtube-dl/options.rb
+++ b/lib/youtube-dl/options.rb
@@ -81,6 +81,13 @@ module YoutubeDL
       @store[key.to_sym] = value
     end
 
+    def with(hash)
+      merged = Options.new(@store.merge(hash.to_h))
+      merged.banned_keys = @banned_keys
+      merged.send(:remove_banned)
+      merged
+    end
+
     # Option getting and setting using ghost methods
     #
     # @param method [Symbol] method name

--- a/lib/youtube-dl/video.rb
+++ b/lib/youtube-dl/video.rb
@@ -27,7 +27,8 @@ module YoutubeDL
     # @param options [Hash] Options to populate the everything with
     def initialize(url, options = {})
       @url = url
-      @options = YoutubeDL::Options.new(options)
+      @options = YoutubeDL::Options.new(options.merge(default_options))
+      @options.banned_keys = banned_keys
     end
 
     # Download the video.
@@ -35,8 +36,7 @@ module YoutubeDL
       raise ArgumentError.new('url cannot be nil') if @url.nil?
       raise ArgumentError.new('url cannot be empty') if @url.empty?
 
-      @download_options = YoutubeDL::Options.new(runner_options)
-      set_information_from_json(YoutubeDL::Runner.new(url, @download_options).run)
+      set_information_from_json(YoutubeDL::Runner.new(url, runner_options).run)
     end
 
     alias_method :get, :download
@@ -74,12 +74,22 @@ module YoutubeDL
   private
 
     # Add in other default options here.
-    def runner_options
+    def default_options
       {
         color: false,
         progress: false,
         print_json: true
-      }.merge(@options)
+      }
+    end
+
+    def banned_keys
+      [
+        :get_filename
+      ]
+    end
+
+    def runner_options
+      YoutubeDL::Options.new(@options.to_h.merge(default_options))
     end
 
     def set_information_from_json(json) # :nodoc:
@@ -87,7 +97,7 @@ module YoutubeDL
     end
 
     def grab_information_without_download # :nodoc:
-      set_information_from_json(YoutubeDL::Runner.new(url, runner_options.merge({skip_download: true})).run)
+      set_information_from_json(YoutubeDL::Runner.new(url, runner_options.with({skip_download: true})).run)
     end
   end
 end

--- a/test/youtube-dl/options_test.rb
+++ b/test/youtube-dl/options_test.rb
@@ -1,8 +1,12 @@
 require_relative '../test_helper'
 
 describe YoutubeDL::Options do
+  let(:example_pair) { {parent_key: 'parent value'} }
+  let(:banned_pair) { {banned_key: 'Outlaw Country! Whoo!'} }
+
   before do
     @options = YoutubeDL::Options.new
+    @options.banned_keys.push :banned_key
   end
 
   describe '#initialize' do
@@ -36,6 +40,11 @@ describe YoutubeDL::Options do
 
     it 'should be equal to store' do
       assert_equal @options.store, @options.to_hash
+    end
+
+    it 'should not include banned keys' do
+      @options.store.merge! banned_pair
+      refute_includes @options.to_h, :banned_key
     end
   end
 
@@ -81,6 +90,15 @@ describe YoutubeDL::Options do
       assert_equal opts.store[:parent], 'value'
       assert_equal opts.store[:child], 'vlaue'
     end
+
+    it 'should remove any banned keys automatically' do
+      @options.configure do |c|
+        c.parent_key = 'parent value'
+        c.banned_key = 'nope'
+      end
+
+      assert_equal example_pair, @options.store
+    end
   end
 
   describe '#[], #[]==' do
@@ -97,6 +115,16 @@ describe YoutubeDL::Options do
         assert @options.store.keys.include?(d), "keys not symbolizing automatically: #{d}"
       end
     end
+
+    it 'should remove any banned keys automatically' do
+      @options[:banned_key] = 'nope'
+      refute_includes @options.store, :banned_key
+    end
+
+    it 'should not return any banned keys' do
+      @options.store.merge! banned_pair
+      assert_nil @options[:banned_key]
+    end
   end
 
   describe '#method_missing' do
@@ -110,6 +138,16 @@ describe YoutubeDL::Options do
       @options.store[:walrus] = 'haswalrus'
 
       assert @options.walrus == 'haswalrus'
+    end
+
+    it 'should remove any banned keys automatically' do
+      @options.banned_key = 'nope'
+      refute_includes @options.store, :banned_key
+    end
+
+    it 'should not return any banned keys' do
+      @options.store.merge! banned_pair
+      assert_nil @options.banned_key
     end
   end
 
@@ -140,6 +178,16 @@ describe YoutubeDL::Options do
     it 'should return instance of Options when calling sanitize_keys' do
       @options.store['some-key'] = "some_value"
       assert_instance_of YoutubeDL::Options, @options.sanitize_keys
+    end
+  end
+
+  describe '#banned?' do
+    it 'should return true for a banned key' do
+      assert @options.banned?(:banned_key), "Key :banned_key was not banned"
+    end
+
+    it 'should return false for a not banned key' do
+      refute @options.banned?(:not_banned_key), "Key :not_banned_key was banned"
     end
   end
 end

--- a/test/youtube-dl/options_test.rb
+++ b/test/youtube-dl/options_test.rb
@@ -127,6 +127,27 @@ describe YoutubeDL::Options do
     end
   end
 
+  describe '#with' do
+    let(:addon_pair) { {secondary_key: 'secondary value'} }
+
+    before do
+      @options.store.merge! example_pair
+    end
+
+    it 'should merge @store and given hash' do
+      assert_equal example_pair.merge(addon_pair), @options.with(addon_pair).to_h
+    end
+
+    it 'should not affect @store directly' do
+      @options.with(addon_pair)
+      assert_equal example_pair, @options.store
+    end
+
+    it 'should not include banned keys' do
+      refute_includes @options.with(banned_pair).to_h, :banned_key
+    end
+  end
+
   describe '#method_missing' do
     it 'should be able to set options with method_missing' do
       @options.test = true

--- a/test/youtube-dl/video_test.rb
+++ b/test/youtube-dl/video_test.rb
@@ -114,6 +114,15 @@ describe YoutubeDL::Video do
     it 'should be an OpenStruct' do
       assert_instance_of OpenStruct, @information
     end
+
+    it 'does not cause unexpected behavior when get_filename is true' do
+      @video.options.get_filename = true
+
+      # Test will error out if JSON::ParserError is raised.
+      assert_silent do
+        @video.download
+      end
+    end
   end
 
   describe '#method_missing' do


### PR DESCRIPTION
* Added `banned_keys` to `Options` class. This let's you set banned keys on an options object and it won't store or return those banned keys. 
* Added `Options#with` helper, for quickly merging an arbitrary hash with an options object.
* Integrated `banned_keys` into `Video` class. 
* Refactored `runner_options` into `default_options` (the default option hash) and `runner_options` (factory method for generating `Options` object from default options and currently stored options.) 
* Fixes #34 