### PR TITLE
Version 0.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ before_install:
 - sudo chmod 755 ./vendor/bin/youtube-dl
 - sudo apt-get update -qq
 
+bundler_args: --without extras
+
 rvm:
 - 2.0.0 # Too old stable
 - 2.1.8 # Old stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
   allow_failures:
   - rvm: jruby
   - rvm: jruby-head
+  - rvm: ruby-head
 
 notifications:
   slack: layer8x:cvixULdjCINfq7u9Zs1rS0VY

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,9 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in youtube-dl.rb.gemspec
 gemspec
+
+group :extras do
+  gem 'pry'
+  gem 'pry-byebug'
+  gem 'm'
+end

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Ruby wrapper for [youtube-dl](http://rg3.github.io/youtube-dl/).
 [![Inline docs](http://inch-ci.org/github/layer8x/youtube-dl.rb.svg?branch=master)](http://inch-ci.org/github/layer8x/youtube-dl.rb)
 [![Dependency Status](https://gemnasium.com/layer8x/youtube-dl.rb.svg)](https://gemnasium.com/layer8x/youtube-dl.rb)
 
+[![Build history for master branch](https://buildstats.info/travisci/chart/layer8x/youtube-dl.rb?branch=master&buildCount=50)]
 [![Stories in Ready](https://badge.waffle.io/layer8x/youtube-dl.rb.svg?label=ready&title=Ready)](http://waffle.io/layer8x/youtube-dl.rb)
 
 

--- a/lib/youtube-dl/options.rb
+++ b/lib/youtube-dl/options.rb
@@ -4,6 +4,9 @@ module YoutubeDL
     # @return [Hash] key value storage object
     attr_accessor :store
 
+    # @return [Array] array of keys that won't be saved to the options store
+    attr_accessor :banned_keys
+
     # Options initializer
     #
     # @param options [Hash] a hash of options
@@ -13,12 +16,15 @@ module YoutubeDL
       else
         @store = options.to_h
       end
+
+      @banned_keys = []
     end
 
     # Returns options as a hash
     #
     # @return [Hash] hash of options
     def to_hash
+      remove_banned
       @store
     end
     alias_method :to_h, :to_hash
@@ -50,6 +56,8 @@ module YoutubeDL
     # @yield [config] self
     def configure
       yield(self) if block_given?
+      remove_banned
+      self
     end
 
     # Get option with brackets syntax
@@ -57,6 +65,8 @@ module YoutubeDL
     # @param key [Object] key
     # @return [Object] value
     def [](key)
+      remove_banned
+      return nil if banned? key
       @store[key.to_sym]
     end
 
@@ -66,7 +76,16 @@ module YoutubeDL
     # @param value [Object] value
     # @return [Object] whatever Hash#= returns
     def []=(key, value)
+      remove_banned
+      return nil if banned? key
       @store[key.to_sym] = value
+    end
+
+    def with(hash)
+      merged = Options.new(@store.merge(hash.to_h))
+      merged.banned_keys = @banned_keys
+      merged.send(:remove_banned)
+      merged
     end
 
     # Option getting and setting using ghost methods
@@ -76,10 +95,13 @@ module YoutubeDL
     # @param block [Proc] implicit block given
     # @return [Object] the value of method in the options store
     def method_missing(method, *args, &_block)
+      remove_banned
       if method.to_s.include? '='
         method = method.to_s.tr('=', '').to_sym
+        return nil if banned? method
         @store[method] = args.first
       else
+        return nil if banned? method
         @store[method]
       end
     end
@@ -120,7 +142,15 @@ module YoutubeDL
       safe_copy
     end
 
-    private
+    # Check if key is a banned key
+    #
+    # @param key [Object] key to check
+    # @return [Boolean] true if key is banned, false if not.
+    def banned?(key)
+      @banned_keys.include? key
+    end
+
+  private
 
     # Helper function to convert option keys into command-line-friendly parameters
     #
@@ -128,6 +158,11 @@ module YoutubeDL
     # @return [String] paramized key
     def paramize(key)
       key.to_s.tr('_', '-')
+    end
+
+    # Helper to remove banned keys from store
+    def remove_banned
+      @store.delete_if { |key, value| banned? key }
     end
   end
 end

--- a/lib/youtube-dl/version.rb
+++ b/lib/youtube-dl/version.rb
@@ -1,5 +1,5 @@
 module YoutubeDL
   # Semantic Version as well as the bundled binary version.
   # "(major).(minor).(teeny).(pre-release).(binary-version)"
-  VERSION = '0.3.1-dev.2016.03.14'.freeze
+  VERSION = '0.3.1-dev.2016.06.16'.freeze
 end

--- a/lib/youtube-dl/version.rb
+++ b/lib/youtube-dl/version.rb
@@ -1,5 +1,5 @@
 module YoutubeDL
   # Semantic Version as well as the bundled binary version.
   # "(major).(minor).(teeny).(pre-release).(binary-version)"
-  VERSION = '0.3.1-dev.2016.06.16'.freeze
+  VERSION = '0.3.1.2016.06.16'.freeze
 end

--- a/lib/youtube-dl/version.rb
+++ b/lib/youtube-dl/version.rb
@@ -1,5 +1,5 @@
 module YoutubeDL
   # Semantic Version as well as the bundled binary version.
   # "(major).(minor).(teeny).(pre-release).(binary-version)"
-  VERSION = '0.3.0.2016.06.16'
+  VERSION = '0.3.1-dev.2016.03.14'
 end

--- a/lib/youtube-dl/version.rb
+++ b/lib/youtube-dl/version.rb
@@ -1,5 +1,5 @@
 module YoutubeDL
   # Semantic Version as well as the bundled binary version.
   # "(major).(minor).(teeny).(pre-release).(binary-version)"
-  VERSION = '0.3.1-dev.2016.03.14'
+  VERSION = '0.3.1-dev.2016.03.14'.freeze
 end

--- a/lib/youtube-dl/video.rb
+++ b/lib/youtube-dl/video.rb
@@ -45,7 +45,7 @@ module YoutubeDL
     #
     # @return [String] Filename downloaded to
     def filename
-      @information._filename
+      self._filename
     end
 
     # Metadata information for the video, gotten from --print-json

--- a/lib/youtube-dl/video.rb
+++ b/lib/youtube-dl/video.rb
@@ -27,7 +27,8 @@ module YoutubeDL
     # @param options [Hash] Options to populate the everything with
     def initialize(url, options = {})
       @url = url
-      @options = YoutubeDL::Options.new(options)
+      @options = YoutubeDL::Options.new(options.merge(default_options))
+      @options.banned_keys = banned_keys
     end
 
     # Download the video.
@@ -35,8 +36,7 @@ module YoutubeDL
       raise ArgumentError.new('url cannot be nil') if @url.nil?
       raise ArgumentError.new('url cannot be empty') if @url.empty?
 
-      @download_options = YoutubeDL::Options.new(runner_options)
-      set_information_from_json(YoutubeDL::Runner.new(url, @download_options).run)
+      set_information_from_json(YoutubeDL::Runner.new(url, runner_options).run)
     end
 
     alias_method :get, :download
@@ -74,12 +74,22 @@ module YoutubeDL
   private
 
     # Add in other default options here.
-    def runner_options
+    def default_options
       {
         color: false,
         progress: false,
         print_json: true
-      }.merge(@options)
+      }
+    end
+
+    def banned_keys
+      [
+        :get_filename
+      ]
+    end
+
+    def runner_options
+      YoutubeDL::Options.new(@options.to_h.merge(default_options))
     end
 
     def set_information_from_json(json) # :nodoc:
@@ -87,7 +97,7 @@ module YoutubeDL
     end
 
     def grab_information_without_download # :nodoc:
-      set_information_from_json(YoutubeDL::Runner.new(url, runner_options.merge({skip_download: true})).run)
+      set_information_from_json(YoutubeDL::Runner.new(url, runner_options.with({skip_download: true})).run)
     end
   end
 end

--- a/lib/youtube-dl/video.rb
+++ b/lib/youtube-dl/video.rb
@@ -62,7 +62,13 @@ module YoutubeDL
     # @param block [Proc] explict block
     # @return [Object] The value from @information
     def method_missing(method, *args, &block)
-      value = information.send(method, *args, &block)
+      value =
+        if method.to_s.include? '='
+          method = method.to_s.tr('=', '').to_sym
+          information[method] = args.first
+        else
+          information[method]
+        end
 
       if value.nil?
         super
@@ -93,7 +99,7 @@ module YoutubeDL
     end
 
     def set_information_from_json(json) # :nodoc:
-      @information = OpenStruct.new(JSON.parse(json))
+      @information = JSON.parse(json, symbolize_names: true)
     end
 
     def grab_information_without_download # :nodoc:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,9 +12,9 @@ gem 'minitest'
 require 'minitest/autorun'
 require 'minitest/spec'
 require 'purdytest' # minitest-colorize is broken in minitest version 5
-require 'pry'
 require 'fileutils'
 require 'yaml'
+require 'bundler/setup'
 
 require 'youtube-dl'
 
@@ -34,3 +34,4 @@ end
 def travis_ci?
   !!ENV['TRAVIS']
 end
+Bundler.require(:extras) if defined?(Bundler) && !travis_ci?

--- a/test/youtube-dl/video_test.rb
+++ b/test/youtube-dl/video_test.rb
@@ -122,8 +122,12 @@ describe YoutubeDL::Video do
       @information = @video.information
     end
 
-    it 'should be an OpenStruct' do
-      assert_instance_of OpenStruct, @information
+    it 'should be a Hash' do
+      assert_instance_of Hash, @information
+    end
+
+    it 'should not be empty' do
+      refute_empty @information
     end
 
     it 'does not cause unexpected behavior when get_filename is true' do

--- a/test/youtube-dl/video_test.rb
+++ b/test/youtube-dl/video_test.rb
@@ -125,6 +125,15 @@ describe YoutubeDL::Video do
     it 'should be an OpenStruct' do
       assert_instance_of OpenStruct, @information
     end
+
+    it 'does not cause unexpected behavior when get_filename is true' do
+      @video.options.get_filename = true
+
+      # Test will error out if JSON::ParserError is raised.
+      assert_silent do
+        @video.download
+      end
+    end
   end
 
   describe '#method_missing' do

--- a/youtube-dl.rb.gemspec
+++ b/youtube-dl.rb.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/layer8x/youtube-dl.rb'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']

--- a/youtube-dl.rb.gemspec
+++ b/youtube-dl.rb.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'cocaine', '>=0.5.4'
 
   spec.add_development_dependency 'bundler', '>= 1.6'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'm'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.8.1'
   spec.add_development_dependency 'purdytest'

--- a/youtube-dl.rb.gemspec
+++ b/youtube-dl.rb.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  #spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
* Removed immediate support for ruby-head. 
* Version string freeze
* Fixed video.filename NoMethodError #37
* Refactored a lot of how options are handled within Video class #39 
* Switch to Hash for Video information storage