### PR TITLE
ActiveSupport version warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'activesupport', '< 5.0'
+  gem 'activesupport', '< 5.0' unless RUBY_VERSION >= '2.2.2'
 end
 
 group :extras do

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,10 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in youtube-dl.rb.gemspec
 gemspec
 
+group :test do
+  gem 'activesupport', '< 5.0'
+end
+
 group :extras do
   gem 'pry'
   gem 'pry-byebug'

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ Ruby wrapper for [youtube-dl](http://rg3.github.io/youtube-dl/).
 [![Build history for master branch](https://buildstats.info/travisci/chart/layer8x/youtube-dl.rb?branch=master&buildCount=50)](https://travis-ci.org/layer8x/youtube-dl.rb/builds)
 [![Stories in Ready](https://badge.waffle.io/layer8x/youtube-dl.rb.svg?label=ready&title=Ready)](http://waffle.io/layer8x/youtube-dl.rb)
 
+## Gem::InstallError: activesupport requires Ruby version >= 2.2.2.
+
+This gem indirectly depends on ActiveSupport, but ActiveSupport 5 (the latest version) requires Ruby version >= 2.2.2. If you are using a version older than this, add this line to your `Gemfile`:
+
+```
+gem 'activesupport', '< 5.0'
+```
 
 ## Install the gem
 

--- a/youtube-dl.rb.gemspec
+++ b/youtube-dl.rb.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', ">= 3.0.0", "< 5.0" # HACK: Temporary fix for #44
   spec.add_dependency 'cocaine', '>=0.5.4'
 
   spec.add_development_dependency 'bundler', '>= 1.6'


### PR DESCRIPTION
Adds a warning to the top of the README to add an `activesupport` version constraint to the `Gemfile` when using older Rubies.
