### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ All options available to youtube-dl can be passed to the options hash
 
 ```ruby
 options = {
+  output: 'some_file.mp4',
   username: 'someone',
   password: 'password1',
   rate_limit: '50K',


### PR DESCRIPTION
Options in the readme stated it had all possible options in the example hash, but the output option was not specified, it is kinda confusing since that one is specified right above this. So I added the output option in the example options hash that lists all the possible options